### PR TITLE
feat:products-graphql-queries

### DIFF
--- a/nerdery-ecommerce/package-lock.json
+++ b/nerdery-ecommerce/package-lock.json
@@ -9,13 +9,16 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@apollo/server": "^4.11.2",
         "@handlebars/allow-prototype-access": "^1.0.5",
         "@nestjs-modules/mailer": "^2.0.2",
+        "@nestjs/apollo": "^12.2.2",
         "@nestjs/common": "^10.0.0",
         "@nestjs/config": "^3.3.0",
         "@nestjs/core": "^10.0.0",
         "@nestjs/graphql": "^12.2.2",
         "@nestjs/jwt": "^10.2.0",
+        "@nestjs/mapped-types": "^2.0.6",
         "@nestjs/passport": "^10.0.3",
         "@nestjs/platform-express": "^10.0.0",
         "@nestjs/swagger": "^8.1.0",
@@ -25,6 +28,9 @@
         "bcrypt": "^5.1.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
+        "dataloader": "^2.2.3",
+        "graphql": "^16.10.0",
+        "graphql-tools": "^9.0.8",
         "handlebars": "^4.7.8",
         "ioredis": "^5.4.1",
         "ms": "^2.1.3",
@@ -36,6 +42,7 @@
         "swagger-ui-express": "^5.0.1"
       },
       "devDependencies": {
+        "@faker-js/faker": "^9.3.0",
         "@nestjs/cli": "^10.0.0",
         "@nestjs/schematics": "^10.0.0",
         "@nestjs/testing": "^10.0.0",
@@ -209,6 +216,384 @@
       "dev": true,
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/@apollo/cache-control-types": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@apollo/cache-control-types/-/cache-control-types-1.0.3.tgz",
+      "integrity": "sha512-F17/vCp7QVwom9eG7ToauIKdAxpSoadsJnqIfyryLFSkLSOEqu+eC5Z3N8OXcUVStuOMcNHlyraRsA6rRICu4g==",
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/client": {
+      "version": "3.12.4",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.12.4.tgz",
+      "integrity": "sha512-S/eC9jxEW9Jg1BjD6AZonE1fHxYuvC3gFHop8FRQkUdeK63MmBD5r0DOrN2WlJbwha1MSD6A97OwXwjaujEQpA==",
+      "optional": true,
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@wry/caches": "^1.0.0",
+        "@wry/equality": "^0.5.6",
+        "@wry/trie": "^0.5.0",
+        "graphql-tag": "^2.12.6",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.18.0",
+        "prop-types": "^15.7.2",
+        "rehackt": "^0.1.0",
+        "response-iterator": "^0.2.6",
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.10.3",
+        "tslib": "^2.3.0",
+        "zen-observable-ts": "^1.2.5"
+      },
+      "peerDependencies": {
+        "graphql": "^15.0.0 || ^16.0.0",
+        "graphql-ws": "^5.5.5",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql-ws": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "subscriptions-transport-ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@apollo/protobufjs": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.7.tgz",
+      "integrity": "sha512-Lahx5zntHPZia35myYDBRuF58tlwPskwHc5CWBZC/4bMKB6siTBWwtMrkqXcsNwQiFSzSx5hKdRPUmemrEp3Gg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "apollo-pbjs": "bin/pbjs",
+        "apollo-pbts": "bin/pbts"
+      }
+    },
+    "node_modules/@apollo/server": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-4.11.2.tgz",
+      "integrity": "sha512-WUTHY7DDek8xAMn4Woa9Bl8duQUDzRYQkosX/d1DtCsBWESZyApR7ndnI5d6+W4KSTtqBHhJFkusEI7CWuIJXg==",
+      "dependencies": {
+        "@apollo/cache-control-types": "^1.0.3",
+        "@apollo/server-gateway-interface": "^1.1.1",
+        "@apollo/usage-reporting-protobuf": "^4.1.1",
+        "@apollo/utils.createhash": "^2.0.0",
+        "@apollo/utils.fetcher": "^2.0.0",
+        "@apollo/utils.isnodelike": "^2.0.0",
+        "@apollo/utils.keyvaluecache": "^2.1.0",
+        "@apollo/utils.logger": "^2.0.0",
+        "@apollo/utils.usagereporting": "^2.1.0",
+        "@apollo/utils.withrequired": "^2.0.0",
+        "@graphql-tools/schema": "^9.0.0",
+        "@types/express": "^4.17.13",
+        "@types/express-serve-static-core": "^4.17.30",
+        "@types/node-fetch": "^2.6.1",
+        "async-retry": "^1.2.1",
+        "cors": "^2.8.5",
+        "express": "^4.21.1",
+        "loglevel": "^1.6.8",
+        "lru-cache": "^7.10.1",
+        "negotiator": "^0.6.3",
+        "node-abort-controller": "^3.1.1",
+        "node-fetch": "^2.6.7",
+        "uuid": "^9.0.0",
+        "whatwg-mimetype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16.0"
+      },
+      "peerDependencies": {
+        "graphql": "^16.6.0"
+      }
+    },
+    "node_modules/@apollo/server-gateway-interface": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@apollo/server-gateway-interface/-/server-gateway-interface-1.1.1.tgz",
+      "integrity": "sha512-pGwCl/po6+rxRmDMFgozKQo2pbsSwE91TpsDBAOgf74CRDPXHHtM88wbwjab0wMMZh95QfR45GGyDIdhY24bkQ==",
+      "dependencies": {
+        "@apollo/usage-reporting-protobuf": "^4.1.1",
+        "@apollo/utils.fetcher": "^2.0.0",
+        "@apollo/utils.keyvaluecache": "^2.1.0",
+        "@apollo/utils.logger": "^2.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/server-plugin-landing-page-graphql-playground": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/server-plugin-landing-page-graphql-playground/-/server-plugin-landing-page-graphql-playground-4.0.0.tgz",
+      "integrity": "sha512-PBDtKI/chJ+hHeoJUUH9Kuqu58txQl00vUGuxqiC9XcReulIg7RjsyD0G1u3drX4V709bxkL5S0nTeXfRHD0qA==",
+      "deprecated": "The use of GraphQL Playground in Apollo Server was supported in previous versions, but this is no longer the case as of December 31, 2022. This package exists for v4 migration purposes only. We do not intend to resolve security issues or other bugs with this package if they arise, so please migrate away from this to [Apollo Server's default Explorer](https://www.apollographql.com/docs/apollo-server/api/plugin/landing-pages) as soon as possible.",
+      "dependencies": {
+        "@apollographql/graphql-playground-html": "1.6.29"
+      },
+      "engines": {
+        "node": ">=14.0"
+      },
+      "peerDependencies": {
+        "@apollo/server": "^4.0.0"
+      }
+    },
+    "node_modules/@apollo/server/node_modules/@graphql-tools/merge": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.4.2.tgz",
+      "integrity": "sha512-XbrHAaj8yDuINph+sAfuq3QCZ/tKblrTLOpirK0+CAgNlZUCHs0Fa+xtMUURgwCVThLle1AF7svJCxFizygLsw==",
+      "dependencies": {
+        "@graphql-tools/utils": "^9.2.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@apollo/server/node_modules/@graphql-tools/schema": {
+      "version": "9.0.19",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.19.tgz",
+      "integrity": "sha512-oBRPoNBtCkk0zbUsyP4GaIzCt8C0aCI4ycIRUL67KK5pOHljKLBBtGT+Jr6hkzA74C8Gco8bpZPe7aWFjiaK2w==",
+      "dependencies": {
+        "@graphql-tools/merge": "^8.4.1",
+        "@graphql-tools/utils": "^9.2.1",
+        "tslib": "^2.4.0",
+        "value-or-promise": "^1.0.12"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@apollo/server/node_modules/@graphql-tools/utils": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
+      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@apollo/server/node_modules/@types/express": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@apollo/server/node_modules/@types/express-serve-static-core": {
+      "version": "4.19.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@apollo/server/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@apollo/server/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@apollo/usage-reporting-protobuf": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@apollo/usage-reporting-protobuf/-/usage-reporting-protobuf-4.1.1.tgz",
+      "integrity": "sha512-u40dIUePHaSKVshcedO7Wp+mPiZsaU6xjv9J+VyxpoU/zL6Jle+9zWeG98tr/+SZ0nZ4OXhrbb8SNr0rAPpIDA==",
+      "dependencies": {
+        "@apollo/protobufjs": "1.2.7"
+      }
+    },
+    "node_modules/@apollo/utils.createhash": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.createhash/-/utils.createhash-2.0.1.tgz",
+      "integrity": "sha512-fQO4/ZOP8LcXWvMNhKiee+2KuKyqIcfHrICA+M4lj/h/Lh1H10ICcUtk6N/chnEo5HXu0yejg64wshdaiFitJg==",
+      "dependencies": {
+        "@apollo/utils.isnodelike": "^2.0.1",
+        "sha.js": "^2.4.11"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@apollo/utils.dropunuseddefinitions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.dropunuseddefinitions/-/utils.dropunuseddefinitions-2.0.1.tgz",
+      "integrity": "sha512-EsPIBqsSt2BwDsv8Wu76LK5R1KtsVkNoO4b0M5aK0hx+dGg9xJXuqlr7Fo34Dl+y83jmzn+UvEW+t1/GP2melA==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.fetcher": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.fetcher/-/utils.fetcher-2.0.1.tgz",
+      "integrity": "sha512-jvvon885hEyWXd4H6zpWeN3tl88QcWnHp5gWF5OPF34uhvoR+DFqcNxs9vrRaBBSY3qda3Qe0bdud7tz2zGx1A==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@apollo/utils.isnodelike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.isnodelike/-/utils.isnodelike-2.0.1.tgz",
+      "integrity": "sha512-w41XyepR+jBEuVpoRM715N2ZD0xMD413UiJx8w5xnAZD2ZkSJnMJBoIzauK83kJpSgNuR6ywbV29jG9NmxjK0Q==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@apollo/utils.keyvaluecache": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.1.1.tgz",
+      "integrity": "sha512-qVo5PvUUMD8oB9oYvq4ViCjYAMWnZ5zZwEjNF37L2m1u528x5mueMlU+Cr1UinupCgdB78g+egA1G98rbJ03Vw==",
+      "dependencies": {
+        "@apollo/utils.logger": "^2.0.1",
+        "lru-cache": "^7.14.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@apollo/utils.keyvaluecache/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@apollo/utils.logger": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
+      "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@apollo/utils.printwithreducedwhitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.printwithreducedwhitespace/-/utils.printwithreducedwhitespace-2.0.1.tgz",
+      "integrity": "sha512-9M4LUXV/fQBh8vZWlLvb/HyyhjJ77/I5ZKu+NBWV/BmYGyRmoEP9EVAy7LCVoY3t8BDcyCAGfxJaLFCSuQkPUg==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.removealiases": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.removealiases/-/utils.removealiases-2.0.1.tgz",
+      "integrity": "sha512-0joRc2HBO4u594Op1nev+mUF6yRnxoUH64xw8x3bX7n8QBDYdeYgY4tF0vJReTy+zdn2xv6fMsquATSgC722FA==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.sortast": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.sortast/-/utils.sortast-2.0.1.tgz",
+      "integrity": "sha512-eciIavsWpJ09za1pn37wpsCGrQNXUhM0TktnZmHwO+Zy9O4fu/WdB4+5BvVhFiZYOXvfjzJUcc+hsIV8RUOtMw==",
+      "dependencies": {
+        "lodash.sortby": "^4.7.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.stripsensitiveliterals": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.stripsensitiveliterals/-/utils.stripsensitiveliterals-2.0.1.tgz",
+      "integrity": "sha512-QJs7HtzXS/JIPMKWimFnUMK7VjkGQTzqD9bKD1h3iuPAqLsxd0mUNVbkYOPTsDhUKgcvUOfOqOJWYohAKMvcSA==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.usagereporting": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.usagereporting/-/utils.usagereporting-2.1.0.tgz",
+      "integrity": "sha512-LPSlBrn+S17oBy5eWkrRSGb98sWmnEzo3DPTZgp8IQc8sJe0prDgDuppGq4NeQlpoqEHz0hQeYHAOA0Z3aQsxQ==",
+      "dependencies": {
+        "@apollo/usage-reporting-protobuf": "^4.1.0",
+        "@apollo/utils.dropunuseddefinitions": "^2.0.1",
+        "@apollo/utils.printwithreducedwhitespace": "^2.0.1",
+        "@apollo/utils.removealiases": "2.0.1",
+        "@apollo/utils.sortast": "^2.0.1",
+        "@apollo/utils.stripsensitiveliterals": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.withrequired": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.withrequired/-/utils.withrequired-2.0.1.tgz",
+      "integrity": "sha512-YBDiuAX9i1lLc6GeTy1m7DGLFn/gMnvXqlalOIMjM7DeOgIacEjjfwPqb0M1CQ2v11HhR15d1NmxJoRCfrNqcA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@apollographql/graphql-playground-html": {
+      "version": "1.6.29",
+      "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.29.tgz",
+      "integrity": "sha512-xCcXpoz52rI4ksJSdOCxeOCn2DLocxwHf9dVT/Q90Pte1LX+LY+91SFtJF3KXVHH8kEin+g1KKCQPKBjZJfWNA==",
+      "dependencies": {
+        "xss": "^1.0.8"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1005,6 +1390,22 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.3.0.tgz",
+      "integrity": "sha512-r0tJ3ZOkMd9xsu3VRfqlFR6cz0V/jFYRswAIpC+m/DIfAUXq7g8N7wTAlhSANySXYGKzGryfDXwtwsY8TxEIDw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@graphql-tools/merge": {
@@ -1848,6 +2249,38 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/@nestjs/apollo": {
+      "version": "12.2.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/apollo/-/apollo-12.2.2.tgz",
+      "integrity": "sha512-gsDqSfsmTSvF0k3XaRESRgM3uE/YFO+59txCsq7T1EadDOVOuoF3zVQiFmi6D50Rlnqohqs63qjjf46mgiiXgQ==",
+      "dependencies": {
+        "@apollo/server-plugin-landing-page-graphql-playground": "4.0.0",
+        "iterall": "1.3.0",
+        "lodash.omit": "4.5.0",
+        "tslib": "2.8.1"
+      },
+      "peerDependencies": {
+        "@apollo/gateway": "^2.0.0",
+        "@apollo/server": "^4.3.2",
+        "@apollo/subgraph": "^2.0.0",
+        "@as-integrations/fastify": "^1.3.0 || ^2.0.0",
+        "@nestjs/common": "^9.3.8 || ^10.0.0",
+        "@nestjs/core": "^9.3.8 || ^10.0.0",
+        "@nestjs/graphql": "^12.0.0",
+        "graphql": "^16.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@apollo/gateway": {
+          "optional": true
+        },
+        "@apollo/subgraph": {
+          "optional": true
+        },
+        "@as-integrations/fastify": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/cli": {
       "version": "10.4.9",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-10.4.9.tgz",
@@ -2322,6 +2755,60 @@
         "@prisma/debug": "6.0.1"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -2449,7 +2936,6 @@
       "version": "1.19.5",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
       "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
-      "dev": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -2459,7 +2945,6 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -2538,8 +3023,7 @@
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
-      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
-      "dev": true
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA=="
     },
     "node_modules/@types/ioredis": {
       "version": "5.0.0",
@@ -2604,6 +3088,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
+    },
     "node_modules/@types/methods": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
@@ -2613,8 +3102,7 @@
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "dev": true
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
     },
     "node_modules/@types/mjml": {
       "version": "4.7.4",
@@ -2642,6 +3130,15 @@
       "integrity": "sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA==",
       "dependencies": {
         "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/@types/nodemailer": {
@@ -2691,20 +3188,17 @@
     "node_modules/@types/qs": {
       "version": "6.9.17",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.17.tgz",
-      "integrity": "sha512-rX4/bPcfmvxHDv0XjfJELTTr+iB+tn032nPILqHm5wbthUUUuVtNGGqzhya9XUxjTP8Fpr0qYgSZZKxGY++svQ==",
-      "dev": true
+      "integrity": "sha512-rX4/bPcfmvxHDv0XjfJELTTr+iB+tn032nPILqHm5wbthUUUuVtNGGqzhya9XUxjTP8Fpr0qYgSZZKxGY++svQ=="
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
     },
     "node_modules/@types/send": {
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
       "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
-      "dev": true,
       "dependencies": {
         "@types/mime": "^1",
         "@types/node": "*"
@@ -2714,7 +3208,6 @@
       "version": "1.15.7",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
       "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
-      "dev": true,
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*",
@@ -3103,6 +3596,54 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@wry/caches": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@wry/caches/-/caches-1.0.1.tgz",
+      "integrity": "sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/context": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.4.tgz",
+      "integrity": "sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/equality": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.7.tgz",
+      "integrity": "sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/trie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.5.0.tgz",
+      "integrity": "sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -3530,11 +4071,18 @@
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "devOptional": true
     },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -4337,7 +4885,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -4594,6 +5141,11 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/cssfilter": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
@@ -4644,6 +5196,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dataloader": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.3.tgz",
+      "integrity": "sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA=="
     },
     "node_modules/debug": {
       "version": "4.4.0",
@@ -4749,7 +5306,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -6221,7 +6777,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
       "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -6574,7 +7129,6 @@
       "version": "16.10.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.10.0.tgz",
       "integrity": "sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -6591,6 +7145,73 @@
       },
       "peerDependencies": {
         "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/graphql-tools": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-9.0.8.tgz",
+      "integrity": "sha512-Xc4efKwugzTsswtQ/Vup6VvCBZ1qy/8CR5mVkVkPmWyl7GmTbQzvIteR4Yr2fegtgXxfmY8YiAY2a71yEBjDhA==",
+      "dependencies": {
+        "@graphql-tools/schema": "^10.0.13",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "optionalDependencies": {
+        "@apollo/client": "~3.2.5 || ~3.3.0 || ~3.4.0 || ~3.5.0 || ~3.6.0 || ~3.7.0 || ~3.8.0 || ~3.9.0 || ~3.10.0 || ~3.11.0 || ~3.12.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/graphql-tools/node_modules/@graphql-tools/merge": {
+      "version": "9.0.14",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.14.tgz",
+      "integrity": "sha512-MO7VXnm3ShpdG51hs4hYsLyu+8o/tSLjNYQmLmR4rkHoFi3kQCDu2r8B4IVwd+Ve39cechj0NyCmMsg+mRvwDQ==",
+      "dependencies": {
+        "@graphql-tools/utils": "^10.6.4",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/graphql-tools/node_modules/@graphql-tools/schema": {
+      "version": "10.0.13",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.13.tgz",
+      "integrity": "sha512-1gvTTuSKej9bR5O2SP9dCKSHaQkVmg9fWU0Aia34HMsAZl2bzosUfXjwBu3ze8MWqb+gRVjdhukDpGA5ZC+5nA==",
+      "dependencies": {
+        "@graphql-tools/merge": "^9.0.14",
+        "@graphql-tools/utils": "^10.6.4",
+        "tslib": "^2.4.0",
+        "value-or-promise": "^1.0.12"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/graphql-tools/node_modules/@graphql-tools/utils": {
+      "version": "10.6.4",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.6.4.tgz",
+      "integrity": "sha512-itCgjwVxbO+3uI/K73G9heedG8KelNFzgn368rUhPjTrkJX6NyLQwT5EMq/A8tvazMXyJYdtnN5nD+tT4DUpbQ==",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "cross-inspect": "1.0.1",
+        "dset": "^3.1.2",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/graphql-ws": {
@@ -6747,6 +7368,21 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "optional": true,
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "optional": true
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -8405,7 +9041,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -8777,10 +9413,20 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "node_modules/lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg=="
+    },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+    },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -8796,6 +9442,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "optional": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/lower-case": {
@@ -9581,8 +10256,7 @@
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
-      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
-      "dev": true
+      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ=="
     },
     "node_modules/node-addon-api": {
       "version": "5.1.0",
@@ -9838,6 +10512,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optimism": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.1.tgz",
+      "integrity": "sha512-mLXNwWPa9dgFyDqkNi54sjDyNJ9/fTI6WGBLgnXku1vdKY/jovHfZT5r+aiVeFFLOz+foPNOm5YJ4mqgld2GBQ==",
+      "optional": true,
+      "dependencies": {
+        "@wry/caches": "^1.0.0",
+        "@wry/context": "^0.7.0",
+        "@wry/trie": "^0.5.0",
+        "tslib": "^2.3.0"
       }
     },
     "node_modules/optionator": {
@@ -10435,6 +11121,23 @@
         "node": ">= 6"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "optional": true,
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "optional": true
+    },
     "node_modules/proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -10818,6 +11521,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/rehackt": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/rehackt/-/rehackt-0.1.0.tgz",
+      "integrity": "sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==",
+      "optional": true,
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/relateurl": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
@@ -10910,6 +11631,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/response-iterator": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/response-iterator/-/response-iterator-0.2.6.tgz",
+      "integrity": "sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -10928,6 +11658,14 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/reusify": {
       "version": "1.0.4",
@@ -11411,6 +12149,18 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -11919,7 +12669,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
       "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -12240,6 +12990,18 @@
       },
       "peerDependencies": {
         "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/ts-invariant": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
+      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ts-jest": {
@@ -12982,6 +13744,14 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -13206,6 +13976,26 @@
         }
       }
     },
+    "node_modules/xss": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.15.tgz",
+      "integrity": "sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==",
+      "dependencies": {
+        "commander": "^2.20.3",
+        "cssfilter": "0.0.10"
+      },
+      "bin": {
+        "xss": "bin/xss"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/xss/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -13275,6 +14065,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zen-observable": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
+      "optional": true
+    },
+    "node_modules/zen-observable-ts": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
+      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
+      "optional": true,
+      "dependencies": {
+        "zen-observable": "0.8.15"
       }
     }
   }

--- a/nerdery-ecommerce/package.json
+++ b/nerdery-ecommerce/package.json
@@ -21,13 +21,16 @@
     "seed": "ts-node prisma/seed.ts"
   },
   "dependencies": {
+    "@apollo/server": "^4.11.2",
     "@handlebars/allow-prototype-access": "^1.0.5",
     "@nestjs-modules/mailer": "^2.0.2",
+    "@nestjs/apollo": "^12.2.2",
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.3.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/graphql": "^12.2.2",
     "@nestjs/jwt": "^10.2.0",
+    "@nestjs/mapped-types": "^2.0.6",
     "@nestjs/passport": "^10.0.3",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/swagger": "^8.1.0",
@@ -37,6 +40,9 @@
     "bcrypt": "^5.1.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
+    "dataloader": "^2.2.3",
+    "graphql": "^16.10.0",
+    "graphql-tools": "^9.0.8",
     "handlebars": "^4.7.8",
     "ioredis": "^5.4.1",
     "ms": "^2.1.3",
@@ -48,6 +54,7 @@
     "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
+    "@faker-js/faker": "^9.3.0",
     "@nestjs/cli": "^10.0.0",
     "@nestjs/schematics": "^10.0.0",
     "@nestjs/testing": "^10.0.0",

--- a/nerdery-ecommerce/prisma/faker-products.ts
+++ b/nerdery-ecommerce/prisma/faker-products.ts
@@ -12,7 +12,7 @@ export function generateFakeProduct() {
             isDeleted: false,
             likesCount: 0,
             minPrice: parseFloat(faker.commerce.price({ min: 50, max: 60 })),
-            maxPrice: parseFloat(faker.commerce.price({ min: 50, max: 60 })),
+            maxPrice: parseFloat(faker.commerce.price({ min: 71, max: 85 })),
             category: {
                 connectOrCreate: {
                     create: { name: 'Fake' },
@@ -83,7 +83,7 @@ export function generateFakeProduct() {
             isEnabled: true,
             isDeleted: false,
             likesCount: 0,
-            minPrice: parseFloat(faker.commerce.price({ min: 70, max: 80 })),
+            minPrice: parseFloat(faker.commerce.price({ min: 50, max: 60 })),
             maxPrice: parseFloat(faker.commerce.price({ min: 70, max: 80 })),
             category: {
                 connectOrCreate: {

--- a/nerdery-ecommerce/prisma/faker-products.ts
+++ b/nerdery-ecommerce/prisma/faker-products.ts
@@ -1,0 +1,155 @@
+import { faker } from '@faker-js/faker';
+import { GenderEnum, Prisma } from "@prisma/client";
+
+export function generateFakeProduct() {
+    const productData: Prisma.ProductCreateInput[] = [
+        {
+            name: faker.commerce.productName(),
+            gender: GenderEnum.MALE,
+            thumbnailUrl: faker.image.url({ width: 200, height: 300 }),
+            description: faker.commerce.productDescription(),
+            isEnabled: true,
+            isDeleted: false,
+            likesCount: 0,
+            minPrice: parseFloat(faker.commerce.price({ min: 50, max: 60 })),
+            maxPrice: parseFloat(faker.commerce.price({ min: 50, max: 60 })),
+            category: {
+                connectOrCreate: {
+                    create: { name: 'Fake' },
+                    where: { name: 'Fake' },
+                },
+            },
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            productVariations: {
+                create: [
+                    {
+                        price: parseFloat(faker.commerce.price({ min: 20, max: 60 })),
+                        discount: 10.0,
+                        discountType: 'FIXED',
+                        size: faker.helpers.arrayElement(['S', 'M', 'L', 'XL']),
+                        color: faker.color.human(),
+                        stock: faker.number.int({ min: 20, max: 30 }),
+                        isEnabled: true,
+                        isDeleted: false,
+                        variationImages: {
+                            create: [
+                                { imageUrl: faker.image.url({ width: 200, height: 300 }) },
+                                { imageUrl: faker.image.url({ width: 200, height: 300 }) },
+                            ],
+                        },
+                    },
+                    {
+                        price: parseFloat(faker.commerce.price({ min: 20, max: 60 })),
+                        discount: 5.0,
+                        discountType: 'PERCENTAGE',
+                        size: faker.helpers.arrayElement(['S', 'M', 'L', 'XL']),
+                        color: 'Blue',
+                        stock: faker.number.int(50),
+                        isEnabled: true,
+                        isDeleted: false,
+                        variationImages: {
+                            create: [
+                                { imageUrl: faker.image.url({ height: 200, width: 200 }) },
+                                { imageUrl: faker.image.url() },
+                            ],
+                        },
+                    },
+                    {
+                        price: parseFloat(faker.commerce.price({ min: 20, max: 60 })),
+                        discount: 0.0,
+                        discountType: 'NONE',
+                        size: faker.helpers.arrayElement(['S', 'M', 'L', 'XL']),
+                        color: faker.color.human(),
+                        stock: faker.number.int(30),
+                        isEnabled: true,
+                        isDeleted: false,
+                        variationImages: {
+                            create: [
+                                { imageUrl: faker.image.url() },
+                                { imageUrl: faker.image.url() },
+                                { imageUrl: faker.image.url() },
+                            ],
+                        },
+                    },
+                ],
+            },
+        },
+        {
+            name: faker.commerce.productName(),
+            gender: GenderEnum.FEMALE,
+            thumbnailUrl: faker.image.url(),
+            description: faker.commerce.productDescription(),
+            isEnabled: true,
+            isDeleted: false,
+            likesCount: 0,
+            minPrice: parseFloat(faker.commerce.price({ min: 70, max: 80 })),
+            maxPrice: parseFloat(faker.commerce.price({ min: 70, max: 80 })),
+            category: {
+                connectOrCreate: {
+                    create: { name: 'Fake' },
+                    where: { name: 'Fake' },
+                },
+            },
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            productVariations: {
+                create: [
+                    {
+                        price: parseFloat(faker.commerce.price({ min: 70, max: 80 })),
+                        discount: 15.0,
+                        discountType: 'PERCENTAGE',
+                        size: faker.helpers.arrayElement(['S', 'M', 'L', 'XL']),
+                        color: faker.color.human(),
+                        stock: faker.number.int(20),
+                        isEnabled: true,
+                        isDeleted: false,
+                        variationImages: {
+                            create: [
+                                { imageUrl: faker.image.url() },
+                                { imageUrl: faker.image.url() },
+                                { imageUrl: faker.image.url() },
+                            ],
+                        },
+                    },
+                    {
+                        price: parseFloat(faker.commerce.price({ min: 70, max: 80 })),
+                        discount: 10.0,
+                        discountType: 'PERCENTAGE',
+                        size: faker.helpers.arrayElement(['S', 'M', 'L', 'XL']),
+                        color: faker.color.human(),
+                        stock: faker.number.int(40),
+                        isEnabled: true,
+                        isDeleted: false,
+                        variationImages: {
+                            create: [
+                                { imageUrl: faker.image.url() },
+                                { imageUrl: faker.image.url() },
+                                { imageUrl: faker.image.url() },
+                            ],
+                        },
+                    },
+                    {
+                        price: parseFloat(faker.commerce.price({ min: 70, max: 80 })),
+                        discount: 19.99,
+                        discountType: 'FIXED',
+                        size: faker.helpers.arrayElement(['S', 'M', 'L', 'XL']),
+                        color: faker.color.human(),
+                        stock: faker.number.int(15),
+                        isEnabled: true,
+                        isDeleted: false,
+                        variationImages: {
+                            create: [
+                                { imageUrl: faker.image.url() },
+                                { imageUrl: faker.image.url() },
+                            ],
+                        },
+                    },
+                ],
+            },
+        },
+    ];
+
+    return productData;
+}
+

--- a/nerdery-ecommerce/prisma/migrations/20241218055459_init/migration.sql
+++ b/nerdery-ecommerce/prisma/migrations/20241218055459_init/migration.sql
@@ -94,7 +94,7 @@ CREATE TABLE "Product" (
     "thumbnailUrl" VARCHAR(255) NOT NULL,
     "categoryId" UUID NOT NULL,
     "description" TEXT,
-    "isEnable" BOOLEAN NOT NULL,
+    "isEnabled" BOOLEAN NOT NULL,
     "isDeleted" BOOLEAN NOT NULL,
     "likesCount" INTEGER NOT NULL,
     "minPrice" DECIMAL(10,2) NOT NULL,
@@ -116,7 +116,7 @@ CREATE TABLE "ProductVariation" (
     "color" VARCHAR(20) NOT NULL,
     "stock" INTEGER NOT NULL,
     "stockRefilledAt" TIMESTAMP(3),
-    "isEnable" BOOLEAN NOT NULL DEFAULT false,
+    "isEnabled" BOOLEAN NOT NULL DEFAULT false,
     "isDeleted" BOOLEAN NOT NULL DEFAULT false,
 
     CONSTRAINT "ProductVariation_pkey" PRIMARY KEY ("id")

--- a/nerdery-ecommerce/prisma/schema.prisma
+++ b/nerdery-ecommerce/prisma/schema.prisma
@@ -167,7 +167,7 @@ model ProductVariation {
   size            String           @db.VarChar(10)
   color           String           @db.VarChar(20)
   stock           Int
-  stockRefilledAt DateTime?
+  stockRefilledAt DateTime?        @updatedAt
   isEnabled       Boolean          @default(false)
   isDeleted       Boolean          @default(false)
   product         Product          @relation(fields: [productId], references: [id])

--- a/nerdery-ecommerce/prisma/schema.prisma
+++ b/nerdery-ecommerce/prisma/schema.prisma
@@ -126,7 +126,7 @@ model Category {
   parentCategoryId String?    @db.Uuid
   parentCategory   Category?  @relation("CategoryParent", fields: [parentCategoryId], references: [id])
   subCategories    Category[] @relation("CategoryParent")
-  product          Product[]
+  products         Product[]
 
   @@index([name], type: Hash)
 }
@@ -138,7 +138,7 @@ model Product {
   thumbnailUrl      String             @db.VarChar(255)
   categoryId        String             @db.Uuid
   description       String?
-  isEnable          Boolean
+  isEnabled         Boolean
   isDeleted         Boolean
   likesCount        Int
   minPrice          Decimal            @db.Decimal(10, 2)
@@ -168,7 +168,7 @@ model ProductVariation {
   color           String           @db.VarChar(20)
   stock           Int
   stockRefilledAt DateTime?
-  isEnable        Boolean          @default(false)
+  isEnabled       Boolean          @default(false)
   isDeleted       Boolean          @default(false)
   product         Product          @relation(fields: [productId], references: [id])
   variationImages VariationImage[]

--- a/nerdery-ecommerce/prisma/seed.ts
+++ b/nerdery-ecommerce/prisma/seed.ts
@@ -5,6 +5,7 @@ import {
   DiscountTypeEnum,
 } from '@prisma/client';
 import * as bcrypt from 'bcrypt';
+import { generateFakeProduct } from './faker-products';
 
 const clientRoleName = 'Client';
 const managerRoleName = 'Manager';
@@ -71,7 +72,7 @@ const productData: Prisma.ProductCreateInput[] = [
     gender: GenderEnum.UNISEX,
     thumbnailUrl: 'https://picsum.photos/200/300',
     description: 'High-performance running shoes for all terrains.',
-    isEnable: true,
+    isEnabled: true,
     isDeleted: false,
     likesCount: 0,
     minPrice: 59.99,
@@ -98,7 +99,7 @@ const productData: Prisma.ProductCreateInput[] = [
           size: 'M',
           color: 'Black',
           stock: 100,
-          isEnable: true,
+          isEnabled: true,
           isDeleted: false,
           variationImages: {
             create: [
@@ -114,7 +115,7 @@ const productData: Prisma.ProductCreateInput[] = [
           size: 'L',
           color: 'Blue',
           stock: 50,
-          isEnable: true,
+          isEnabled: true,
           isDeleted: false,
           variationImages: {
             create: [
@@ -130,7 +131,7 @@ const productData: Prisma.ProductCreateInput[] = [
           size: 'XL',
           color: 'Red',
           stock: 30,
-          isEnable: true,
+          isEnabled: true,
           isDeleted: false,
           variationImages: {
             create: [
@@ -157,7 +158,7 @@ const productData: Prisma.ProductCreateInput[] = [
     gender: GenderEnum.MALE,
     thumbnailUrl: 'https://picsum.photos/200/300',
     description: 'Stylish and comfortable sports jacket.',
-    isEnable: true,
+    isEnabled: true,
     isDeleted: false,
     likesCount: 0,
     minPrice: 89.99,
@@ -173,7 +174,7 @@ const productData: Prisma.ProductCreateInput[] = [
           size: 'S',
           color: 'Green',
           stock: 20,
-          isEnable: true,
+          isEnabled: true,
           isDeleted: false,
           variationImages: {
             create: [
@@ -189,7 +190,7 @@ const productData: Prisma.ProductCreateInput[] = [
           size: 'M',
           color: 'Black',
           stock: 40,
-          isEnable: true,
+          isEnabled: true,
           isDeleted: false,
           variationImages: {
             create: [
@@ -205,7 +206,7 @@ const productData: Prisma.ProductCreateInput[] = [
           size: 'L',
           color: 'Blue',
           stock: 15,
-          isEnable: true,
+          isEnabled: true,
           isDeleted: false,
           variationImages: {
             create: [
@@ -219,24 +220,355 @@ const productData: Prisma.ProductCreateInput[] = [
   },
 ];
 
+// https://www.adidas.com/us/men-pants
+const productDataMen: Prisma.ProductCreateInput[] = [
+  {
+    name: 'Track Pants',
+    gender: GenderEnum.MALE,
+    thumbnailUrl: 'https://example.com/mens-track-pants.jpg',
+    description: 'Comfortable and durable track pants for men.',
+    isEnabled: true,
+    isDeleted: false,
+    likesCount: 0,
+    minPrice: 49.99,
+    maxPrice: 69.99,
+    category: {
+      connectOrCreate: {
+        create: { name: 'Pants' },
+        where: { name: 'Pants' },
+      },
+    },
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    productVariations: {
+      create: [
+        {
+          price: 49.99,
+          discount: 5.0,
+          discountType: DiscountTypeEnum.PERCENTAGE,
+          size: 'M',
+          color: 'Black',
+          stock: 100,
+          isEnabled: true,
+          isDeleted: false,
+          variationImages: {
+            create: [
+              { imageUrl: 'https://example.com/mens-track-pants-black.jpg' },
+              {
+                imageUrl: 'https://example.com/mens-track-pants-black-side.jpg',
+              },
+            ],
+          },
+        },
+        {
+          price: 59.99,
+          discount: 10.0,
+          discountType: DiscountTypeEnum.FIXED,
+          size: 'L',
+          color: 'Navy Blue',
+          stock: 50,
+          isEnabled: true,
+          isDeleted: false,
+          variationImages: {
+            create: [
+              { imageUrl: 'https://example.com/mens-track-pants-blue.jpg' },
+              {
+                imageUrl: 'https://example.com/mens-track-pants-blue-back.jpg',
+              },
+            ],
+          },
+        },
+        {
+          price: 69.99,
+          discount: 0.0,
+          discountType: DiscountTypeEnum.NONE,
+          size: 'XL',
+          color: 'Grey',
+          stock: 30,
+          isEnabled: true,
+          isDeleted: false,
+          variationImages: {
+            create: [
+              { imageUrl: 'https://example.com/mens-track-pants-grey.jpg' },
+              {
+                imageUrl: 'https://example.com/mens-track-pants-grey-side.jpg',
+              },
+            ],
+          },
+        },
+      ],
+    },
+  },
+  {
+    name: 'Sweatpants',
+    gender: GenderEnum.MALE,
+    thumbnailUrl: 'https://example.com/mens-sweatpants.jpg',
+    description: 'Soft and cozy sweatpants for everyday wear.',
+    isEnabled: true,
+    isDeleted: false,
+    likesCount: 0,
+    minPrice: 39.99,
+    maxPrice: 59.99,
+    category: {
+      connectOrCreate: {
+        create: { name: 'Pants' },
+        where: { name: 'Pants' },
+      },
+    },
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    productVariations: {
+      create: [
+        {
+          price: 39.99,
+          discount: 0.0,
+          discountType: DiscountTypeEnum.NONE,
+          size: 'S',
+          color: 'Black',
+          stock: 50,
+          isEnabled: true,
+          isDeleted: false,
+          variationImages: {
+            create: [
+              { imageUrl: 'https://example.com/mens-sweatpants-black.jpg' },
+              {
+                imageUrl: 'https://example.com/mens-sweatpants-black-back.jpg',
+              },
+            ],
+          },
+        },
+        {
+          price: 49.99,
+          discount: 10.0,
+          discountType: DiscountTypeEnum.FIXED,
+          size: 'M',
+          color: 'Grey',
+          stock: 70,
+          isEnabled: true,
+          isDeleted: false,
+          variationImages: {
+            create: [
+              { imageUrl: 'https://example.com/mens-sweatpants-grey.jpg' },
+              { imageUrl: 'https://example.com/mens-sweatpants-grey-side.jpg' },
+            ],
+          },
+        },
+        {
+          price: 59.99,
+          discount: 5.0,
+          discountType: DiscountTypeEnum.PERCENTAGE,
+          size: 'L',
+          color: 'Navy Blue',
+          stock: 40,
+          isEnabled: true,
+          isDeleted: false,
+          variationImages: {
+            create: [
+              { imageUrl: 'https://example.com/mens-sweatpants-blue.jpg' },
+              { imageUrl: 'https://example.com/mens-sweatpants-blue-back.jpg' },
+            ],
+          },
+        },
+      ],
+    },
+  },
+];
+
+// https://www.adidas.com/us/women-hoodies_sweatshirts
+const productDataWomen: Prisma.ProductCreateInput[] = [
+  {
+    name: 'Hoodie',
+    gender: GenderEnum.FEMALE,
+    thumbnailUrl: 'https://example.com/womens-hoodie.jpg',
+    description: 'Stylish and warm hoodie for women.',
+    isEnabled: true,
+    isDeleted: false,
+    likesCount: 0,
+    minPrice: 59.99,
+    maxPrice: 79.99,
+    category: {
+      connectOrCreate: {
+        create: { name: 'Hoodies' },
+        where: { name: 'Hoodies' },
+      },
+    },
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    productVariations: {
+      create: [
+        {
+          price: 59.99,
+          discount: 10.0,
+          discountType: DiscountTypeEnum.PERCENTAGE,
+          size: 'S',
+          color: 'Pink',
+          stock: 80,
+          isEnabled: true,
+          isDeleted: false,
+          variationImages: {
+            create: [
+              { imageUrl: 'https://example.com/womens-hoodie-pink.jpg' },
+              { imageUrl: 'https://example.com/womens-hoodie-pink-back.jpg' },
+            ],
+          },
+        },
+        {
+          price: 69.99,
+          discount: 5.0,
+          discountType: DiscountTypeEnum.PERCENTAGE,
+          size: 'M',
+          color: 'Grey',
+          stock: 60,
+          isEnabled: true,
+          isDeleted: false,
+          variationImages: {
+            create: [
+              { imageUrl: 'https://example.com/womens-hoodie-grey.jpg' },
+              { imageUrl: 'https://example.com/womens-hoodie-grey-side.jpg' },
+            ],
+          },
+        },
+        {
+          price: 79.99,
+          discount: 0.0,
+          discountType: DiscountTypeEnum.NONE,
+          size: 'L',
+          color: 'Black',
+          stock: 40,
+          isEnabled: true,
+          isDeleted: false,
+          variationImages: {
+            create: [
+              { imageUrl: 'https://example.com/womens-hoodie-black.jpg' },
+              { imageUrl: 'https://example.com/womens-hoodie-black-back.jpg' },
+            ],
+          },
+        },
+      ],
+    },
+  },
+  {
+    name: 'Sweatshirt',
+    gender: GenderEnum.FEMALE,
+    thumbnailUrl: 'https://example.com/womens-sweatshirt.jpg',
+    description: 'Cozy sweatshirt with a trendy design.',
+    isEnabled: true,
+    isDeleted: false,
+    likesCount: 0,
+    minPrice: 49.99,
+    maxPrice: 69.99,
+    category: {
+      connectOrCreate: {
+        create: { name: 'Hoodies & Sweatshirts' },
+        where: { name: 'Hoodies & Sweatshirts' },
+      },
+    },
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    productVariations: {
+      create: [
+        {
+          price: 49.99,
+          discount: 0.0,
+          discountType: DiscountTypeEnum.NONE,
+          size: 'S',
+          color: 'White',
+          stock: 70,
+          isEnabled: true,
+          isDeleted: false,
+          variationImages: {
+            create: [
+              { imageUrl: 'https://example.com/womens-sweatshirt-white.jpg' },
+              {
+                imageUrl:
+                  'https://example.com/womens-sweatshirt-white-side.jpg',
+              },
+            ],
+          },
+        },
+        {
+          price: 59.99,
+          discount: 10.0,
+          discountType: DiscountTypeEnum.FIXED,
+          size: 'M',
+          color: 'Blue',
+          stock: 50,
+          isEnabled: true,
+          isDeleted: false,
+          variationImages: {
+            create: [
+              { imageUrl: 'https://example.com/womens-sweatshirt-blue.jpg' },
+              {
+                imageUrl: 'https://example.com/womens-sweatshirt-blue-back.jpg',
+              },
+            ],
+          },
+        },
+        {
+          price: 69.99,
+          discount: 0.0,
+          discountType: DiscountTypeEnum.NONE,
+          size: 'L',
+          color: 'Black',
+          stock: 30,
+          isEnabled: true,
+          isDeleted: false,
+          variationImages: {
+            create: [
+              { imageUrl: 'https://example.com/womens-sweatshirt-black.jpg' },
+              {
+                imageUrl:
+                  'https://example.com/womens-sweatshirt-black-side.jpg',
+              },
+            ],
+          },
+        },
+      ],
+    },
+  },
+];
+
+let count = 0;
+async function insertProducts(products: Prisma.ProductCreateInput[]) {
+  for (const prod of products) {
+    try {
+      if (
+        await prisma.product.findFirst({
+          where: {
+            name: prod.name,
+            gender: prod.gender,
+            description: prod.description,
+          },
+        })
+      ) {
+        continue;
+      }
+      await prisma.product.create({ data: prod });
+      console.log(`${++count}\tProduct ${prod.name} created.`);
+    } catch (error) {
+      console.error(error);
+    }
+  }
+}
+
 async function main() {
   console.log(`Start seeding ...`);
   console.log(`deleting all data ...`);
-  // await prisma.variationImage.deleteMany();
-  // await prisma.productVariation.deleteMany();
-  // await prisma.product.deleteMany();
-  // await prisma.category.deleteMany();
-  // await prisma.refreshToken.deleteMany();
-  // await prisma.passwordReset.deleteMany();
-  // await prisma.userRole.deleteMany();
-  // await prisma.rolePermission.deleteMany();
-  // await prisma.cartItem.deleteMany();
-  // await prisma.orderIncident.deleteMany();
-  // await prisma.stripePayment.deleteMany();
-  // await prisma.orderItem.deleteMany();
-  // await prisma.order.deleteMany();
-  // await prisma.user.deleteMany();
-  // await prisma.permission.deleteMany();
+  await prisma.variationImage.deleteMany();
+  await prisma.productVariation.deleteMany();
+  await prisma.product.deleteMany();
+  await prisma.category.deleteMany();
+  await prisma.refreshToken.deleteMany();
+  await prisma.passwordReset.deleteMany();
+  await prisma.userRole.deleteMany();
+  await prisma.rolePermission.deleteMany();
+  await prisma.cartItem.deleteMany();
+  await prisma.orderIncident.deleteMany();
+  await prisma.stripePayment.deleteMany();
+  await prisma.orderItem.deleteMany();
+  await prisma.order.deleteMany();
+  await prisma.user.deleteMany();
+  await prisma.permission.deleteMany();
 
   console.log(`Start seeding ...`);
 
@@ -263,25 +595,41 @@ async function main() {
     }
   }
 
-  console.log(`Creating users ...`);
+  console.log(`Creating products (manual) ...`);
+  await Promise.all([
+    insertProducts(productData),
+    insertProducts(productDataMen),
+    insertProducts(productDataWomen),
+  ]);
 
-  for (const prod of productData) {
-    try {
-      if (
-        await prisma.product.findFirst({
-          where: {
-            name: prod.name,
-            gender: prod.gender,
-            description: prod.description,
-          },
-        })
-      ) {
-        continue;
-      }
-      await prisma.product.create({ data: prod });
-    } catch (error) {
-      console.error(error);
-    }
+  for (let i = 0; i < 25; i++) {
+    console.log(`Creating fake product round: ${i} ...`);
+    await insertProducts(generateFakeProduct());
+  }
+
+  console.log(`Calculating real max-min.`);
+  const products = await prisma.product.findMany({
+    include: { productVariations: true },
+  });
+
+  for (const product of products) {
+    const minPrice = product.productVariations.reduce(
+      (min, p) => (p.price < min ? p.price : min),
+      product.minPrice,
+    );
+    const maxPrice = product.productVariations.reduce(
+      (max, p) => (p.price > max ? p.price : max),
+      product.maxPrice,
+    );
+
+    let newData = {};
+    if (minPrice) newData['minPrice'] = minPrice;
+    if (maxPrice) newData['maxPrice'] = maxPrice;
+
+    await prisma.product.update({
+      where: { id: product.id },
+      data: newData,
+    });
   }
 
   console.log(`Seeding finished.`);

--- a/nerdery-ecommerce/src/app.module.ts
+++ b/nerdery-ecommerce/src/app.module.ts
@@ -11,7 +11,6 @@ import { ProductsModule } from './products/products.module';
 import { CategoriesModule } from './categories/categories.module';
 import { ApolloDriver } from '@nestjs/apollo';
 import { ProductVariationsModule } from './product-variations/product-variations.module';
-import { BorrarModule } from './borrar/borrar.module';
 import { ProductVariationImagesModule } from './product-variation-images/product-variation-images.module';
 
 @Module({
@@ -34,7 +33,6 @@ import { ProductVariationImagesModule } from './product-variation-images/product
     ProductsModule,
     ProductVariationsModule,
     CategoriesModule,
-    BorrarModule,
     ProductVariationImagesModule,
 
   ],

--- a/nerdery-ecommerce/src/app.module.ts
+++ b/nerdery-ecommerce/src/app.module.ts
@@ -6,6 +6,13 @@ import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
 import { MailModule } from './mail/mail.module';
 import config from './common/config/config';
+import { GraphQLModule } from '@nestjs/graphql';
+import { ProductsModule } from './products/products.module';
+import { CategoriesModule } from './categories/categories.module';
+import { ApolloDriver } from '@nestjs/apollo';
+import { ProductVariationsModule } from './product-variations/product-variations.module';
+import { BorrarModule } from './borrar/borrar.module';
+import { ProductVariationImagesModule } from './product-variation-images/product-variation-images.module';
 
 @Module({
   imports: [
@@ -17,6 +24,19 @@ import config from './common/config/config';
       load: [config],
     }),
     MailModule,
+    GraphQLModule.forRoot({
+      driver: ApolloDriver,
+      autoSchemaFile: true,
+      playground: true,
+      debug: true,
+      introspection: true,
+    }),
+    ProductsModule,
+    ProductVariationsModule,
+    CategoriesModule,
+    BorrarModule,
+    ProductVariationImagesModule,
+
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/nerdery-ecommerce/src/auth/auth.controller.ts
+++ b/nerdery-ecommerce/src/auth/auth.controller.ts
@@ -28,8 +28,7 @@ import { ResetPasswordDto } from './dto/resetPassword.dto';
 @Controller()
 export class AuthController {
   constructor(
-    private readonly authService: AuthService,
-    private jwtService: JwtService,
+    private readonly authService: AuthService
   ) { }
 
   @Get('me')

--- a/nerdery-ecommerce/src/categories/categories.module.ts
+++ b/nerdery-ecommerce/src/categories/categories.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { CategoriesService } from './categories.service';
+import { CategoriesResolver } from './categories.resolver';
+import { PrismaModule } from 'src/prisma/prisma.module';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Module({
+  providers: [CategoriesResolver, CategoriesService, PrismaService],
+})
+export class CategoriesModule { }

--- a/nerdery-ecommerce/src/categories/categories.resolver.ts
+++ b/nerdery-ecommerce/src/categories/categories.resolver.ts
@@ -1,10 +1,6 @@
 import { Resolver, Query, Args, Mutation } from '@nestjs/graphql';
 import { CategoriesService } from './categories.service';
 import { Category } from './entities/category.entity';
-import { CreateCategoryInput } from './dto/create-category.input';
-import { UpdateCategoryInput } from './dto/update-category.input';
-import { SearchInput } from './dto/search.input';
-import { Search } from '@nestjs/common';
 
 @Resolver(() => Category)
 export class CategoriesResolver {

--- a/nerdery-ecommerce/src/categories/categories.resolver.ts
+++ b/nerdery-ecommerce/src/categories/categories.resolver.ts
@@ -1,0 +1,18 @@
+import { Resolver, Query, Args, Mutation } from '@nestjs/graphql';
+import { CategoriesService } from './categories.service';
+import { Category } from './entities/category.entity';
+import { CreateCategoryInput } from './dto/create-category.input';
+import { UpdateCategoryInput } from './dto/update-category.input';
+import { SearchInput } from './dto/search.input';
+import { Search } from '@nestjs/common';
+
+@Resolver(() => Category)
+export class CategoriesResolver {
+  constructor(private readonly categoriesService: CategoriesService) { }
+
+  @Query(() => [Category])
+  async categories(@Args('search', { nullable: true }) search: string) {
+    return this.categoriesService.findBySearch(search);
+  }
+
+}

--- a/nerdery-ecommerce/src/categories/categories.service.spec.ts
+++ b/nerdery-ecommerce/src/categories/categories.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CategoriesService } from './categories.service';
+
+describe('CategoriesService', () => {
+  let service: CategoriesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CategoriesService],
+    }).compile();
+
+    service = module.get<CategoriesService>(CategoriesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/nerdery-ecommerce/src/categories/categories.service.ts
+++ b/nerdery-ecommerce/src/categories/categories.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class CategoriesService {
+  constructor(private readonly prisma: PrismaService) { }
+
+  async findBySearch(search: string) {
+    if (!search) {
+      return this.prisma.category.findMany({
+        include: { subCategories: true, products: true },
+      });
+    }
+
+    return this.prisma.category.findMany({
+      where: {
+        name: {
+          contains: search,
+          mode: 'insensitive',
+        }
+      },
+      include: { subCategories: true, products: true },
+    });
+  }
+
+}

--- a/nerdery-ecommerce/src/categories/categories.service.ts
+++ b/nerdery-ecommerce/src/categories/categories.service.ts
@@ -23,4 +23,15 @@ export class CategoriesService {
     });
   }
 
+  async findByIds(ids: string[]) {
+    return this.prisma.category.findMany({
+      where: {
+        id: {
+          in: ids,
+        },
+      },
+    });
+  }
+
+
 }

--- a/nerdery-ecommerce/src/categories/entities/category.entity.ts
+++ b/nerdery-ecommerce/src/categories/entities/category.entity.ts
@@ -1,0 +1,20 @@
+import { ObjectType, Field, ID } from '@nestjs/graphql';
+import { Product } from 'src/products/entities/product.entity';
+
+@ObjectType()
+export class Category {
+  @Field(() => ID)
+  id: string;
+
+  @Field()
+  name: string;
+
+  @Field(() => ID, { nullable: true })
+  parentId?: string;
+
+  @Field(() => [Category], { nullable: true })
+  subCategories?: Category[];
+
+  @Field(() => [Product])
+  products: Product[];
+}

--- a/nerdery-ecommerce/src/common/enums/discount-type.enum.ts
+++ b/nerdery-ecommerce/src/common/enums/discount-type.enum.ts
@@ -1,8 +1,11 @@
 import { registerEnumType } from '@nestjs/graphql';
+import { DiscountTypeEnum, GenderEnum, Prisma } from '@prisma/client';
 
-export enum DiscountType {
-    PERCENTAGE = 'PERCENTAGE',
-    DOLLAR_SIGN = 'DOLLAR_SIGN',
-}
+// export enum DiscountType {
+//     PERCENTAGE = 'PERCENTAGE',
+//     DOLLAR_SIGN = 'DOLLAR_SIGN',
+// }
 
-registerEnumType(DiscountType, { name: 'DiscountType' });
+export { DiscountTypeEnum as DiscountType };
+
+registerEnumType(DiscountTypeEnum, { name: 'DiscountType' });

--- a/nerdery-ecommerce/src/common/enums/discount-type.enum.ts
+++ b/nerdery-ecommerce/src/common/enums/discount-type.enum.ts
@@ -1,0 +1,8 @@
+import { registerEnumType } from '@nestjs/graphql';
+
+export enum DiscountType {
+    PERCENTAGE = 'PERCENTAGE',
+    DOLLAR_SIGN = 'DOLLAR_SIGN',
+}
+
+registerEnumType(DiscountType, { name: 'DiscountType' });

--- a/nerdery-ecommerce/src/common/enums/gender.enum.ts
+++ b/nerdery-ecommerce/src/common/enums/gender.enum.ts
@@ -1,10 +1,7 @@
 import { registerEnumType } from '@nestjs/graphql';
+import { GenderEnum } from '@prisma/client';
 
-export enum Gender {
-    MALE = 'MALE',
-    FEMALE = 'FEMALE',
-    UNISEX = 'UNISEX',
-    KIDS = 'KIDS',
-}
 
-registerEnumType(Gender, { name: 'Gender' });
+export { GenderEnum as Gender };
+
+registerEnumType(GenderEnum, { name: 'Gender' });

--- a/nerdery-ecommerce/src/common/enums/gender.enum.ts
+++ b/nerdery-ecommerce/src/common/enums/gender.enum.ts
@@ -1,0 +1,10 @@
+import { registerEnumType } from '@nestjs/graphql';
+
+export enum Gender {
+    MALE = 'MALE',
+    FEMALE = 'FEMALE',
+    UNISEX = 'UNISEX',
+    KIDS = 'KIDS',
+}
+
+registerEnumType(Gender, { name: 'Gender' });

--- a/nerdery-ecommerce/src/common/enums/sort-order.enum.ts
+++ b/nerdery-ecommerce/src/common/enums/sort-order.enum.ts
@@ -1,0 +1,8 @@
+import { registerEnumType } from '@nestjs/graphql';
+
+export enum SortOrder {
+    ASC = 'asc',
+    DESC = 'desc',
+}
+
+registerEnumType(SortOrder, { name: 'SortOrder' });

--- a/nerdery-ecommerce/src/common/pagination/pagination-meta.object.ts
+++ b/nerdery-ecommerce/src/common/pagination/pagination-meta.object.ts
@@ -1,0 +1,16 @@
+import { ObjectType, Field, Int } from '@nestjs/graphql';
+
+@ObjectType()
+export class PaginationMeta {
+    @Field(() => Int)
+    totalItems: number;
+
+    @Field(() => Int)
+    totalPages: number;
+
+    @Field(() => Int)
+    limit: number;
+
+    @Field(() => Int)
+    page: number;
+}

--- a/nerdery-ecommerce/src/common/pagination/pagination.input.ts
+++ b/nerdery-ecommerce/src/common/pagination/pagination.input.ts
@@ -1,0 +1,17 @@
+import { InputType, Field, Int } from '@nestjs/graphql';
+import { IsInt, IsOptional, IsPositive } from 'class-validator';
+
+@InputType()
+export class PaginationInput {
+    @Field(() => Int, { defaultValue: 1 }) // Default to page 1
+    @IsInt()
+    @IsOptional()
+    @IsPositive()
+    page?: number;
+
+    @Field(() => Int, { defaultValue: 20 }) // Default to 20 items per page
+    @IsInt()
+    @IsOptional()
+    @IsPositive()
+    limit?: number;
+}

--- a/nerdery-ecommerce/src/common/pagination/pagination.input.ts
+++ b/nerdery-ecommerce/src/common/pagination/pagination.input.ts
@@ -3,13 +3,13 @@ import { IsInt, IsOptional, IsPositive } from 'class-validator';
 
 @InputType()
 export class PaginationInput {
-    @Field(() => Int, { defaultValue: 1 }) // Default to page 1
+    @Field(() => Int, { nullable: true, defaultValue: 1 }) // Default to page 1
     @IsInt()
     @IsOptional()
     @IsPositive()
     page?: number;
 
-    @Field(() => Int, { defaultValue: 20 }) // Default to 20 items per page
+    @Field(() => Int, { nullable: true, defaultValue: 20 }) // Default to 20 items per page
     @IsInt()
     @IsOptional()
     @IsPositive()

--- a/nerdery-ecommerce/src/common/scalars/date-time.scalar.ts
+++ b/nerdery-ecommerce/src/common/scalars/date-time.scalar.ts
@@ -1,0 +1,24 @@
+import { CustomScalar, Scalar } from '@nestjs/graphql';
+import { Kind, ValueNode } from 'graphql';
+
+@Scalar('DateTime')
+export class DateTimeScalar implements CustomScalar<string, Date> {
+    description = 'DateTime custom scalar type';
+
+    parseValue(value: string): Date {
+        return new Date(value); // from client
+    }
+
+    serialize(value: Date): string {
+        return value.toISOString(); // to client
+    }
+
+    parseLiteral(ast: ValueNode): Date {
+        if (ast.kind === Kind.STRING) {
+            return new Date(ast.value);
+        }
+        return null;
+    }
+}
+
+//TODO: CHECK THIS IF I'M GOING TO USE A LIBRARY??

--- a/nerdery-ecommerce/src/prisma/prisma.module.ts
+++ b/nerdery-ecommerce/src/prisma/prisma.module.ts
@@ -5,4 +5,4 @@ import { PrismaService } from './prisma.service';
 @Module({
   providers: [PrismaService],
 })
-export class PrismaModule {}
+export class PrismaModule { }

--- a/nerdery-ecommerce/src/prisma/prisma.service.ts
+++ b/nerdery-ecommerce/src/prisma/prisma.service.ts
@@ -3,6 +3,16 @@ import { PrismaClient } from '@prisma/client';
 
 @Injectable()
 export class PrismaService extends PrismaClient implements OnModuleInit, OnModuleDestroy {
+  /**
+   *
+   */
+  constructor() {
+    super({
+      log: ['query', 'info', 'warn', 'error'], // Logs all Prisma query activity
+      errorFormat: 'pretty', // Makes Prisma error output pretty
+    });
+  }
+
   async onModuleInit() {
     await this.$connect();
   }

--- a/nerdery-ecommerce/src/product-variation-images/dto/create-product-variation-image.input.ts
+++ b/nerdery-ecommerce/src/product-variation-images/dto/create-product-variation-image.input.ts
@@ -1,0 +1,7 @@
+import { InputType, Int, Field } from '@nestjs/graphql';
+
+@InputType()
+export class CreateProductVariationImageInput {
+  @Field(() => Int, { description: 'Example field (placeholder)' })
+  exampleField: number;
+}

--- a/nerdery-ecommerce/src/product-variation-images/dto/update-product-variation-image.input.ts
+++ b/nerdery-ecommerce/src/product-variation-images/dto/update-product-variation-image.input.ts
@@ -1,0 +1,8 @@
+import { CreateProductVariationImageInput } from './create-product-variation-image.input';
+import { InputType, Field, Int, PartialType } from '@nestjs/graphql';
+
+@InputType()
+export class UpdateProductVariationImageInput extends PartialType(CreateProductVariationImageInput) {
+  @Field(() => Int)
+  id: number;
+}

--- a/nerdery-ecommerce/src/product-variation-images/entities/product-variation-image.entity.ts
+++ b/nerdery-ecommerce/src/product-variation-images/entities/product-variation-image.entity.ts
@@ -1,0 +1,21 @@
+import { ObjectType, Field, Int } from '@nestjs/graphql';
+import { isNotEmpty, IsUrl, IsUUID } from 'class-validator';
+import { ProductVariation } from 'src/product-variations/entities/product-variation.entity';
+
+@ObjectType()
+export class ProductVariationImage {
+  @Field()
+  @IsUUID()
+  id: string;
+
+  @Field()
+  @IsUrl()
+  imageUrl: string;
+
+  @Field()
+  @IsUUID()
+  productVariationId: string;
+
+  @Field(() => ProductVariation)
+  productVariation: ProductVariation;
+}

--- a/nerdery-ecommerce/src/product-variation-images/product-variation-images.module.ts
+++ b/nerdery-ecommerce/src/product-variation-images/product-variation-images.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { ProductVariationImagesService } from './product-variation-images.service';
+import { ProductVariationImagesResolver } from './product-variation-images.resolver';
+
+@Module({
+  providers: [ProductVariationImagesResolver, ProductVariationImagesService],
+})
+export class ProductVariationImagesModule {}

--- a/nerdery-ecommerce/src/product-variation-images/product-variation-images.resolver.ts
+++ b/nerdery-ecommerce/src/product-variation-images/product-variation-images.resolver.ts
@@ -1,0 +1,12 @@
+import { Resolver, Query, Mutation, Args, Int } from '@nestjs/graphql';
+import { ProductVariationImagesService } from './product-variation-images.service';
+import { ProductVariationImage } from './entities/product-variation-image.entity';
+import { CreateProductVariationImageInput } from './dto/create-product-variation-image.input';
+import { UpdateProductVariationImageInput } from './dto/update-product-variation-image.input';
+
+@Resolver(() => ProductVariationImage)
+export class ProductVariationImagesResolver {
+  constructor(private readonly productVariationImagesService: ProductVariationImagesService) { }
+
+
+}

--- a/nerdery-ecommerce/src/product-variation-images/product-variation-images.service.spec.ts
+++ b/nerdery-ecommerce/src/product-variation-images/product-variation-images.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProductVariationImagesService } from './product-variation-images.service';
+
+describe('ProductVariationImagesService', () => {
+  let service: ProductVariationImagesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ProductVariationImagesService],
+    }).compile();
+
+    service = module.get<ProductVariationImagesService>(ProductVariationImagesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/nerdery-ecommerce/src/product-variation-images/product-variation-images.service.ts
+++ b/nerdery-ecommerce/src/product-variation-images/product-variation-images.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+import { CreateProductVariationImageInput } from './dto/create-product-variation-image.input';
+import { UpdateProductVariationImageInput } from './dto/update-product-variation-image.input';
+
+@Injectable()
+export class ProductVariationImagesService {
+
+}

--- a/nerdery-ecommerce/src/product-variations/dto/create-product-variation.input.ts
+++ b/nerdery-ecommerce/src/product-variations/dto/create-product-variation.input.ts
@@ -1,0 +1,26 @@
+import { InputType, Field, Float } from '@nestjs/graphql';
+import { DiscountType } from 'src/common/enums/discount-type.enum';
+
+@InputType()
+export class CreateProductVariationInput {
+  @Field(() => Float)
+  price: number;
+
+  @Field(() => Float, { nullable: true })
+  discount?: number;
+
+  @Field(() => DiscountType, { nullable: true })
+  discountType?: DiscountType;
+
+  @Field(() => String)
+  size: string;
+
+  @Field(() => String)
+  color: string;
+
+  @Field(() => Number)
+  stock: number;
+
+  @Field(() => Boolean)
+  isEnabled: boolean;
+}

--- a/nerdery-ecommerce/src/product-variations/dto/update-product-variation.input.ts
+++ b/nerdery-ecommerce/src/product-variations/dto/update-product-variation.input.ts
@@ -1,0 +1,9 @@
+import { InputType, Field, PartialType } from '@nestjs/graphql';
+import { CreateProductVariationInput } from './create-product-variation.input';
+
+@InputType()
+export class UpdateProductVariationInput extends PartialType(CreateProductVariationInput) {
+  //TODO: should left the id here???
+  @Field(() => String)
+  id: string;
+}

--- a/nerdery-ecommerce/src/product-variations/entities/product-variation.entity.ts
+++ b/nerdery-ecommerce/src/product-variations/entities/product-variation.entity.ts
@@ -1,0 +1,43 @@
+import { ObjectType, Field, ID, Float } from '@nestjs/graphql';
+import { DiscountType } from 'src/common/enums/discount-type.enum';
+import { ProductVariationImage } from 'src/product-variation-images/entities/product-variation-image.entity';
+import { Product } from 'src/products/entities/product.entity';
+
+@ObjectType()
+export class ProductVariation {
+  @Field(() => ID)
+  id: string;
+
+  @Field(() => Float)
+  price: number;
+
+  @Field(() => Float, { nullable: true })
+  discount?: number;
+
+  @Field(() => DiscountType, { nullable: true })
+  discountType?: DiscountType;
+
+  @Field(() => String)
+  size: string;
+
+  @Field(() => String)
+  color: string;
+
+  @Field(() => Number)
+  stock: number;
+
+  @Field(() => String)
+  stockRefilledAt: string;
+
+  @Field(() => Boolean)
+  isEnabled: boolean;
+
+  @Field(() => Boolean)
+  isDeleted: boolean;
+
+  @Field(() => Product)
+  product: Product;
+
+  @Field(() => [ProductVariationImage])
+  variationImages: ProductVariationImage[];
+}

--- a/nerdery-ecommerce/src/product-variations/product-variations.module.ts
+++ b/nerdery-ecommerce/src/product-variations/product-variations.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ProductVariationsService } from './product-variations.service';
+import { ProductVariationsResolver } from './product-variations.resolver';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Module({
+  providers: [ProductVariationsResolver, ProductVariationsService, PrismaService],
+})
+export class ProductVariationsModule { }

--- a/nerdery-ecommerce/src/product-variations/product-variations.resolver.ts
+++ b/nerdery-ecommerce/src/product-variations/product-variations.resolver.ts
@@ -1,0 +1,22 @@
+import { Resolver, Query, Mutation, Args } from '@nestjs/graphql';
+import { ProductVariationsService } from './product-variations.service';
+import { ProductVariation } from './entities/product-variation.entity';
+import { UpdateProductVariationInput } from './dto/update-product-variation.input';
+import { CreateProductVariationInput } from './dto/create-product-variation.input';
+import { isUUID, IsUUID } from 'class-validator';
+import { ParseUUIDPipe } from '@nestjs/common';
+
+@Resolver(() => ProductVariation)
+export class ProductVariationsResolver {
+  constructor(private readonly productVariationsService: ProductVariationsService) { }
+
+  @Query(() => [ProductVariation])
+  productVariations(@Args('productId', { type: () => String }, ParseUUIDPipe) productId: string) {
+    return this.productVariationsService.findAll(productId);
+  }
+
+  @Query(() => ProductVariation, { nullable: true })
+  productVariationById(@Args('id', { type: () => String }, ParseUUIDPipe) id: string) {
+    return this.productVariationsService.findOne(id);
+  }
+}

--- a/nerdery-ecommerce/src/product-variations/product-variations.service.spec.ts
+++ b/nerdery-ecommerce/src/product-variations/product-variations.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProductVariationsService } from './product-variations.service';
+
+describe('ProductVariationsService', () => {
+  let service: ProductVariationsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ProductVariationsService],
+    }).compile();
+
+    service = module.get<ProductVariationsService>(ProductVariationsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/nerdery-ecommerce/src/product-variations/product-variations.service.ts
+++ b/nerdery-ecommerce/src/product-variations/product-variations.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { UpdateProductVariationInput } from './dto/update-product-variation.input';
+import { CreateProductVariationInput } from './dto/create-product-variation.input';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class ProductVariationsService {
+  constructor(private readonly prisma: PrismaService) { }
+
+  async findAll(productId: string) {
+    const where = { isDeleted: false, isEnabled: true };
+
+    return await this.prisma.productVariation.findMany({
+      where: { ...where, productId },
+      include: { product: true, variationImages: true },
+    });
+  }
+
+  async findOne(id: string) {
+    const where = { isDeleted: false, isEnabled: true };
+    return await this.prisma.productVariation.findUnique({
+      where: { ...where, id },
+      include: { product: true, variationImages: true },
+    });
+  }
+
+}

--- a/nerdery-ecommerce/src/products/dto/create-product.input.ts
+++ b/nerdery-ecommerce/src/products/dto/create-product.input.ts
@@ -1,0 +1,25 @@
+import { InputType, Field } from '@nestjs/graphql';
+import { IsString, IsUUID, IsBoolean } from 'class-validator';
+import { Gender } from 'src/common/enums/gender.enum';
+
+@InputType()
+export class CreateProductInput {
+  @Field()
+  @IsString()
+  name: string;
+
+  @Field(() => Gender)
+  gender: Gender;
+
+  @Field(() => String)
+  @IsUUID()
+  categoryId: string;
+
+  @Field()
+  @IsString()
+  description: string;
+
+  @Field()
+  @IsBoolean()
+  isEnabled: boolean;
+}

--- a/nerdery-ecommerce/src/products/dto/product-filters.input.ts
+++ b/nerdery-ecommerce/src/products/dto/product-filters.input.ts
@@ -1,0 +1,30 @@
+import { InputType, Field } from '@nestjs/graphql';
+import { Gender } from '../../common/enums/gender.enum';
+import { IsUUID, IsString, IsOptional, IsPositive } from 'class-validator';
+
+@InputType()
+export class ProductFiltersInput {
+    @Field(() => Gender, { nullable: true })
+    @IsOptional()
+    gender?: Gender;
+
+    @Field(() => String, { nullable: true })
+    @IsUUID()
+    @IsOptional()
+    categoryId?: string;
+
+    @Field(() => String, { nullable: true })
+    @IsString()
+    @IsOptional()
+    search?: string;
+
+    @Field(() => Number, { nullable: true })
+    @IsPositive()
+    @IsOptional()
+    minPrice?: number;
+
+    @Field(() => Number, { nullable: true })
+    @IsPositive()
+    @IsOptional()
+    maxPrice?: number;
+}

--- a/nerdery-ecommerce/src/products/dto/products-pagination.object.ts
+++ b/nerdery-ecommerce/src/products/dto/products-pagination.object.ts
@@ -1,0 +1,13 @@
+import { Field, ObjectType } from "@nestjs/graphql";
+import { Product } from "../entities/product.entity";
+import { PaginationMeta } from "src/common/pagination/pagination-meta.object";
+
+@ObjectType()
+export class ProductsPagination {
+    @Field(() => [Product])
+    collection: Product[];
+
+    @Field()
+    meta: PaginationMeta;
+
+}

--- a/nerdery-ecommerce/src/products/dto/sorting-product.input.ts
+++ b/nerdery-ecommerce/src/products/dto/sorting-product.input.ts
@@ -1,7 +1,7 @@
 import { InputType, Field } from '@nestjs/graphql';
 
 import { registerEnumType } from '@nestjs/graphql';
-import { IsOptional } from 'class-validator';
+import { IsNotEmpty, isNotEmpty, IsOptional } from 'class-validator';
 import { SortOrder } from 'src/common/enums/sort-order.enum';
 
 //TODO: match field names with the actual fields in the Product entity
@@ -19,9 +19,10 @@ registerEnumType(ProductSortableField, { name: 'ProductSortableField' });
 @InputType()
 export class SortingProductInput {
     @Field(() => ProductSortableField)
+    @IsNotEmpty()
     field: ProductSortableField;
 
     @Field(() => SortOrder)
-    @IsOptional()
+    @IsNotEmpty()
     order: SortOrder;
 }

--- a/nerdery-ecommerce/src/products/dto/sorting-product.input.ts
+++ b/nerdery-ecommerce/src/products/dto/sorting-product.input.ts
@@ -1,0 +1,27 @@
+import { InputType, Field } from '@nestjs/graphql';
+
+import { registerEnumType } from '@nestjs/graphql';
+import { IsOptional } from 'class-validator';
+import { SortOrder } from 'src/common/enums/sort-order.enum';
+
+//TODO: match field names with the actual fields in the Product entity
+export enum ProductSortableField {
+    NAME = 'name',
+    CREATED_AT = 'createdAt',
+    UPDATED_AT = 'updatedAt',
+    LIKES_COUNT = 'likesCount',
+    PRICE = 'PRICE', // This may be derived from related data.
+}
+
+registerEnumType(ProductSortableField, { name: 'ProductSortableField' });
+
+
+@InputType()
+export class SortingProductInput {
+    @Field(() => ProductSortableField)
+    field: ProductSortableField;
+
+    @Field(() => SortOrder)
+    @IsOptional()
+    order: SortOrder;
+}

--- a/nerdery-ecommerce/src/products/dto/update-product.input.ts
+++ b/nerdery-ecommerce/src/products/dto/update-product.input.ts
@@ -1,0 +1,5 @@
+import { InputType, PartialType } from '@nestjs/graphql';
+import { CreateProductInput } from './create-product.input';
+
+@InputType()
+export class UpdateProductInput extends PartialType(CreateProductInput) { }

--- a/nerdery-ecommerce/src/products/entities/product.entity.ts
+++ b/nerdery-ecommerce/src/products/entities/product.entity.ts
@@ -1,0 +1,52 @@
+import { ObjectType, Field, ID } from '@nestjs/graphql';
+import { Gender } from '../../common/enums/gender.enum';
+import { Category } from '../../categories/entities/category.entity';
+import { ProductVariation } from '../../product-variations/entities/product-variation.entity';
+
+@ObjectType()
+export class Product {
+  @Field(() => ID)
+  id: string;
+
+  @Field()
+  name: string;
+
+  @Field(() => Gender)
+  gender: Gender;
+
+  @Field(() => String, { nullable: true })
+  thumbnailUrl?: string;
+
+  @Field(() => ID)
+  categoryId: string;
+
+  @Field(() => String, { nullable: true })
+  description?: string;
+
+  @Field()
+  isEnabled: boolean;
+
+  @Field()
+  isDeleted: boolean;
+
+  @Field()
+  likesCount: number;
+
+  @Field()
+  minPrice: number;
+
+  @Field()
+  maxPrice: number;
+
+  @Field()
+  createdAt: Date;
+
+  @Field()
+  updatedAt: Date;
+
+  @Field(() => Category)
+  category: Category;
+
+  @Field(() => [ProductVariation], { nullable: true })
+  productVariations?: ProductVariation[];
+}

--- a/nerdery-ecommerce/src/products/products.module.ts
+++ b/nerdery-ecommerce/src/products/products.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ProductsService } from './products.service';
+import { ProductsResolver } from './products.resolver';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Module({
+  providers: [ProductsResolver, ProductsService, PrismaService],
+
+})
+export class ProductsModule { }

--- a/nerdery-ecommerce/src/products/products.resolver.ts
+++ b/nerdery-ecommerce/src/products/products.resolver.ts
@@ -1,0 +1,30 @@
+import { Resolver, Query, Args } from '@nestjs/graphql';
+import { PaginationInput } from 'src/common/pagination/pagination.input';
+
+import { ProductFiltersInput } from './dto/product-filters.input';
+import { ProductsPagination } from './dto/products-pagination.object';
+import { SortingProductInput } from './dto/sorting-product.input';
+import { Product } from './entities/product.entity';
+import { ProductsService } from './products.service';
+import { ParseUUIDPipe } from '@nestjs/common';
+
+@Resolver(() => Product)
+export class ProductsResolver {
+  constructor(private readonly productsService: ProductsService) { }
+
+  @Query(() => ProductsPagination)
+  async products(
+    @Args('filter', { nullable: true }) filter: ProductFiltersInput,
+    @Args('sortBy', { nullable: true }) sortBy: SortingProductInput,
+    @Args('pagination', { nullable: true }) pagination: PaginationInput,
+  ) {
+    return this.productsService.findAll(filter, sortBy, pagination);
+  }
+
+  @Query(() => Product, { nullable: true })
+  async productById(@Args('id', { type: () => String }, ParseUUIDPipe) id: string) {
+    return this.productsService.findById(id);
+  }
+
+
+}

--- a/nerdery-ecommerce/src/products/products.resolver.ts
+++ b/nerdery-ecommerce/src/products/products.resolver.ts
@@ -14,9 +14,9 @@ export class ProductsResolver {
 
   @Query(() => ProductsPagination)
   async products(
-    @Args('filter', { nullable: true }) filter: ProductFiltersInput,
-    @Args('sortBy', { nullable: true }) sortBy: SortingProductInput,
-    @Args('pagination', { nullable: true }) pagination: PaginationInput,
+    @Args('filter', { nullable: true }) filter?: ProductFiltersInput,
+    @Args('sortBy', { nullable: true }) sortBy?: SortingProductInput,
+    @Args('pagination', { nullable: true }) pagination?: PaginationInput,
   ) {
     return this.productsService.findAll(filter, sortBy, pagination);
   }

--- a/nerdery-ecommerce/src/products/products.service.spec.ts
+++ b/nerdery-ecommerce/src/products/products.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProductsService } from './products.service';
+
+describe('ProductsService', () => {
+  let service: ProductsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ProductsService],
+    }).compile();
+
+    service = module.get<ProductsService>(ProductsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/nerdery-ecommerce/src/products/products.service.ts
+++ b/nerdery-ecommerce/src/products/products.service.ts
@@ -1,0 +1,96 @@
+import { Injectable } from '@nestjs/common';
+import { Gender } from 'src/common/enums/gender.enum';
+import { PaginationMeta } from 'src/common/pagination/pagination-meta.object';
+import { PaginationInput } from 'src/common/pagination/pagination.input';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+import { ProductFiltersInput } from './dto/product-filters.input';
+import { ProductSortableField, SortingProductInput } from './dto/sorting-product.input';
+
+@Injectable()
+export class ProductsService {
+  constructor(private readonly prisma: PrismaService) { }
+
+  //TODO: change this any to a proper type
+  async findAll(
+    filters?: ProductFiltersInput,
+    sorting?: SortingProductInput,
+    pagination?: PaginationInput,
+  ): Promise<any> {
+    const { page = 1, limit = 20 } = pagination;
+
+    ///FILTERS IS CUSTOM FOR: gender, minPrice,MaxPrice, category, brand, color, size, rating
+    const where = { isDeleted: false, isEnabled: true };
+    if (filters) {
+      //TODO: add more filters in a generic way if it matches the field name exactly
+      if (filters.gender) {
+        if (filters.gender !== Gender.UNISEX) {
+          where['gender'] = filters.gender;
+        }
+      }
+      if (filters.minPrice) {
+        where['minPrice'] = { gte: filters.minPrice };
+      }
+      if (filters.maxPrice) {
+        where['maxPrice'] = { lte: filters.maxPrice };
+      }
+      if (filters.categoryId) {
+        where['categoryId'] = filters.categoryId;
+      }
+      if (filters.search) {
+        where['name'] = {
+          contains: filters.search,
+          mode: 'insensitive',
+        };
+      }
+    }
+
+    let orderBy = {};
+    if (sorting) {
+      if (sorting.field !== ProductSortableField.PRICE)
+        orderBy = {
+          [sorting.field]: sorting.order,
+        };
+      else {
+        orderBy = {
+          minPrice: sorting.order,
+        };
+      }
+    }
+
+    const totalItems = await this.prisma.product.count({ where });
+    const totalPages = Math.ceil(totalItems / limit);
+    const meta: PaginationMeta = {
+      page,
+      limit,
+      totalItems,
+      totalPages,
+    };
+
+    console.log('meta', meta);
+
+    //TODO: remove include and use ResolveFields
+    //TODO: add DataLoaders to avoid N+1 problem on ResolveFields
+    const collection = await this.prisma.product.findMany({
+      where: where,
+      orderBy: orderBy,
+      skip: (page - 1) * limit,
+      take: limit,
+      include: { category: true, productVariations: true },
+    });
+
+    return {
+      meta,
+      collection,
+    };
+  }
+
+  async findById(id: string) {
+    const where = { isDeleted: false, isEnabled: true };
+
+    return this.prisma.product.findUnique({
+      where: { ...where, id },
+      include: { category: true, productVariations: true },
+    });
+  }
+}

--- a/nerdery-ecommerce/src/products/products.service.ts
+++ b/nerdery-ecommerce/src/products/products.service.ts
@@ -6,6 +6,7 @@ import { PrismaService } from 'src/prisma/prisma.service';
 
 import { ProductFiltersInput } from './dto/product-filters.input';
 import { ProductSortableField, SortingProductInput } from './dto/sorting-product.input';
+import { Product } from '@prisma/client';
 
 @Injectable()
 export class ProductsService {
@@ -93,4 +94,26 @@ export class ProductsService {
       include: { category: true, productVariations: true },
     });
   }
+
+  async findByIds(ids: string[]) {
+    return await this.prisma.product.findMany({
+      where: {
+        id: {
+          in: ids,
+        },
+      },
+    });
+  }
+
+  async findByCategoryIds(categoryIds: string[]) {
+    return await this.prisma.product.findMany({
+      where: {
+        categoryId: {
+          in: categoryIds,
+        },
+      },
+    });
+  }
+
+
 }


### PR DESCRIPTION
## Pull Request: Product Queries

- [x]  Search product by category
- [x]  Search products
    - [x]  with pagination
    - [x]  Sort by (only one at the time)
        - [x]  name
        - [x]  createdAt
        - [ ]  updatedAt
        - [x]  likesCount
        - [x]  price (this has to be custom)
            - [x]  minPrice
            - [x]  maxPrice
    - [x]  Search with filters by (multiple filters can be applied):
        - [x]  gender
        - [x]  categoryId
        - [x]  search
        - [x]  minPrice
        - [x]  maxPrice
- [x]  Search product by Id
- [x]  Search Product Variation by ProductId
- [ ]  See productVariationImages

### By the time being all queries only include 1 level above/below.

Now I have to implement the ResolveFields and Dataloaders for better querying

 

Make sure I can:

- [ ]  Query Category → Product → ProductVariation → ProductVariationImages
- [ ]  Implement Dataloaders:
    - [ ]  On: (not decided yet)